### PR TITLE
fix: OAuth ログインが永遠にローディングする問題を修正

### DIFF
--- a/src/app/actions-oauth.ts
+++ b/src/app/actions-oauth.ts
@@ -2,9 +2,8 @@
 
 import { generateCodeVerifier, generateCodeChallenge, generateState, buildAuthorizationUrl } from '@/lib/oauth/pkce';
 import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 
-export async function signInWithSTEM() {
+export async function signInWithSTEM(): Promise<{ url: string }> {
   const oauthBaseUrl = (process.env.NEXT_PUBLIC_STEM_OAUTH_BASE_URL || 'http://localhost:3000/oauth').replace(/\/$/, '');
   const clientId = process.env.STEM_OAUTH_CLIENT_ID!;
   const appUrl = (process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001').replace(/\/$/, '');
@@ -21,7 +20,7 @@ export async function signInWithSTEM() {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
-    maxAge: 60 * 10, // 10分
+    maxAge: 60 * 10,
     path: '/',
   });
   
@@ -33,7 +32,7 @@ export async function signInWithSTEM() {
     path: '/',
   });
 
-  // OAuth 認可URLを構築してリダイレクト
+  // OAuth 認可URLを構築して返す
   const authUrl = buildAuthorizationUrl({
     authorizationEndpoint: `${oauthBaseUrl}/authorize`,
     clientId,
@@ -42,5 +41,5 @@ export async function signInWithSTEM() {
     state,
   });
 
-  redirect(authUrl);
+  return { url: authUrl };
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 
 'use client'
 
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { signInWithSTEM } from "@/app/actions-oauth"
 import { Icons } from "@/components/icons"
@@ -15,6 +16,18 @@ function LoginContent() {
     const error = searchParams.get('error');
     const isNotRegistered = error === "not_registered";
     const isNotMemberError = error === "指定されたDiscordサーバーのメンバーではありません。";
+    const [isLoading, setIsLoading] = useState(false);
+
+    async function handleLogin() {
+        setIsLoading(true);
+        try {
+            const { url } = await signInWithSTEM();
+            window.location.href = url;
+        } catch (e) {
+            console.error('OAuth login error:', e);
+            setIsLoading(false);
+        }
+    }
 
     return (
         <div className="flex flex-col items-center justify-center p-8">
@@ -59,12 +72,15 @@ function LoginContent() {
                     </Alert>
                 )}
                 
-                <form action={signInWithSTEM} className="mt-8">
-                    <Button type="submit" className="w-full bg-primary hover:bg-primary/90 text-white" size="lg">
-                        <Icons.Logo className="w-5 h-5 mr-2" />
-                        STEMでログイン
-                    </Button>
-                </form>
+                <Button 
+                    onClick={handleLogin} 
+                    disabled={isLoading}
+                    className="w-full mt-8 bg-primary hover:bg-primary/90 text-white" 
+                    size="lg"
+                >
+                    <Icons.Logo className="w-5 h-5 mr-2" />
+                    {isLoading ? 'リダイレクト中...' : 'STEMでログイン'}
+                </Button>
             </div>
         </div>
     )


### PR DESCRIPTION
Server Actionの`redirect()`は外部URL（別ドメイン）へのリダイレクトで無限ローディングになる。URLを返してクライアント側で`window.location.href`を使う方式に修正。